### PR TITLE
make copy of locs before applying masks

### DIFF
--- a/quot/gui/masker.py
+++ b/quot/gui/masker.py
@@ -661,9 +661,10 @@ def apply_masks(point_sets, locs, mode="single_point"):
             did not fall into any mask.
 
     """
-    assigned = np.zeros(len(locs), dtype=np.int64)
+    locs_copy = locs.copy()
+    assigned = np.zeros(len(locs_copy), dtype=np.int64)
     for i, point_set in enumerate(point_sets):
-        assigned[inside_mask(point_set, locs, mode=mode)] = i+1 
+        assigned[inside_mask(point_set, locs_copy, mode=mode)] = i+1 
     return assigned 
 
 def show_mask_assignments(point_sets, locs, mask_col="mask_index",


### PR DESCRIPTION
Avoids leaving a "inside_mask" column in the passed locs DF, despite explicitly dropping in line 611 of inside_mask(). No idea why. It's important to kick this column out, because "inside_mask" will only be true for the last applied mask when multiple masks are applied. Some sample code and data that shows this [here](https://drive.google.com/file/d/1wIHlTL0Dz3-elRDUz98iRFEPVQNnikum/view?usp=share_link).