### PR TITLE
Change LLR defaults to more sensible values

### DIFF
--- a/quot/gui/CONFIG.toml
+++ b/quot/gui/CONFIG.toml
@@ -268,14 +268,14 @@
         minimum = 0.1
         maximum = 7.0
         interval = 0.1
-        init_value = 1.3
+        init_value = 1.5
         type = "float"
     [detect_slider_config.llr.w]
         name = "w"
         minimum = 3
         maximum = 25
-        interval = 1
-        init_value = 15
+        interval = 2
+        init_value = 11
         type = "int"
     [detect_slider_config.llr.t]
         name = "t"

--- a/quot/stock_config.toml
+++ b/quot/stock_config.toml
@@ -10,13 +10,13 @@
 [detect]
     method = "llr"
     k = 1.5
-    w = 21
+    w = 11
     t = 16.0
 
 # Subpixel localization settings
 [localize]
     method = 'ls_int_gaussian'
-    window_size = 9
+    window_size = 11
     sigma = 1.5
     ridge = 0.0001
     convergence = 0.0001

--- a/samples/sample_config.toml
+++ b/samples/sample_config.toml
@@ -9,15 +9,15 @@
 # Spot detection settings
 [detect]
     method = "llr"
-    k = 1.2
-    w = 15
+    k = 1.5
+    w = 11
     t = 18.0
 
 # Subpixel localization settings
 [localize]
     method = 'ls_int_gaussian'
-    window_size = 9
-    sigma = 1.2
+    window_size = 11
+    sigma = 1.5
     ridge = 0.0001
     max_iter = 10
     damp = 0.3


### PR DESCRIPTION
Just some adjustments in default values for LLR to make them consistent between the GUI and the `quot config` command. 1.5 pixels is usually better as a kernel width than 1.3 pixels in practice.